### PR TITLE
Change ELB security group "Name" to match "GroupName"

### DIFF
--- a/terraform/template.go
+++ b/terraform/template.go
@@ -384,7 +384,7 @@ resource "aws_security_group" "elb" {
   vpc_id      = "${aws_vpc.default.id}"
 
   tags {
-    Name = "${var.deployment}-concourse"
+    Name = "${var.deployment}-elb"
     concourse-up-project = "${var.project}"
     concourse-up-component = "concourse"
   }


### PR DESCRIPTION
This PR changes the ELB's security group "Name" to match the "GroupName".

This mirrors the settings of the other 3 SGs, and removes a potential source of confusion when viewing the SGs in the AWS console (note the mismatch of the 2nd entry in the table):

![screen shot 2017-07-21 at 11 37 36](https://user-images.githubusercontent.com/224508/28460249-1db8911a-6e09-11e7-86be-6dd9234e4739.png)
